### PR TITLE
Fix typos, add tests and improve voice assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to your Lovable project
+# FoodieAI Companion
 
 ## Project info
 
@@ -20,6 +20,9 @@ If you want to work locally using your own IDE, you can clone this repo and push
 
 The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 
+This project uses **npm** as the package manager. The `bun.lockb` file is leftover
+from a previous experiment and can be ignored.
+
 Follow these steps:
 
 ```sh
@@ -34,6 +37,9 @@ npm i
 
 # Step 4: Start the development server with auto-reloading and an instant preview.
 npm run dev
+
+# Step 5: Run the unit tests.
+npm test
 ```
 
 **Edit a file directly in GitHub**

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@capacitor/android": "^7.4.0",
@@ -82,6 +83,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -212,7 +212,7 @@ const MenubarShortcut = ({
     />
   )
 }
-MenubarShortcut.displayname = "MenubarShortcut"
+MenubarShortcut.displayName = "MenubarShortcut"
 
 export {
   Menubar,

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -16,9 +16,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/src/services/voiceAssistant.ts
+++ b/src/services/voiceAssistant.ts
@@ -94,8 +94,13 @@ export class VoiceAssistantService {
     const lowerText = text.toLowerCase();
     
     // Add food item commands
-    if (lowerText.includes('add') && (lowerText.includes('food') || lowerText.includes('item'))) {
-      const foodMatch = lowerText.match(/add (.+?) to/);
+    if (
+      lowerText.includes('add') &&
+      (lowerText.includes('food') ||
+        lowerText.includes('item') ||
+        lowerText.includes('inventory'))
+    ) {
+      const foodMatch = lowerText.match(/add (.+?)(?: to|$)/);
       const food = foodMatch ? foodMatch[1] : '';
       return {
         intent: 'add_food',
@@ -114,7 +119,10 @@ export class VoiceAssistantService {
     }
 
     // Meal suggestions
-    if (lowerText.includes('meal') && (lowerText.includes('suggest') || lowerText.includes('recommend'))) {
+    if (
+      (lowerText.includes('suggest') || lowerText.includes('recommend')) &&
+      (lowerText.includes('meal') || /(breakfast|lunch|dinner)/.test(lowerText))
+    ) {
       const mealType = lowerText.match(/(breakfast|lunch|dinner)/)?.[1] || 'any';
       return {
         intent: 'suggest_meal',

--- a/tests/voiceAssistant.test.ts
+++ b/tests/voiceAssistant.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { voiceAssistant } from '../src/services/voiceAssistant'
+
+describe('voiceAssistant.parseCommand', () => {
+  it('detects add_food intent', () => {
+    const cmd = voiceAssistant.parseCommand('Add apples to inventory')
+    expect(cmd.intent).toBe('add_food')
+    expect(cmd.entities.food).toBe('apples')
+  })
+
+  it('detects check_expiring intent', () => {
+    const cmd = voiceAssistant.parseCommand('Check expiring items')
+    expect(cmd.intent).toBe('check_expiring')
+  })
+
+  it('detects suggest_meal intent', () => {
+    const cmd = voiceAssistant.parseCommand('Suggest dinner')
+    expect(cmd.intent).toBe('suggest_meal')
+    expect(cmd.entities.mealType).toBe('dinner')
+  })
+
+  it('detects grocery_list intent', () => {
+    const cmd = voiceAssistant.parseCommand('Show grocery list')
+    expect(cmd.intent).toBe('grocery_list')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  }
+})


### PR DESCRIPTION
## Summary
- clarify README about npm usage and add test instructions
- use React Router `Link` on the 404 page
- correct `displayName` typo for `MenubarShortcut`
- expand voice assistant command parsing and add unit tests
- add vitest config file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866fb3d7cb8832f810e0ca62788d7c4